### PR TITLE
[Bug-Yig]: Restrict object tagging resources

### DIFF
--- a/api/generic-handlers.go
+++ b/api/generic-handlers.go
@@ -297,6 +297,7 @@ var notimplementedBucketResourceNames = map[string]bool{
 // List of not implemented object queries
 var notimplementedObjectResourceNames = map[string]bool{
 	"torrent": true,
+	"tagging": true,
 }
 
 func GetBucketAndObjectInfoFromRequest(r *http.Request) (bucketName string, objectName string) {


### PR DESCRIPTION
Currently Yig does not support put Object tagging but disable tagging operation
Signed-off-by: Shenghai <18366182863@163.com>