### PR TITLE
Yig: backport bucket logging

### DIFF
--- a/api/api-router.go
+++ b/api/api-router.go
@@ -107,6 +107,10 @@ func RegisterAPIRouter(mux *router.Router, api ObjectAPIHandlers) {
 		bucket.Methods("GET").HandlerFunc(api.GetBucketCorsHandler).Queries("cors", "")
 		// DeleteBucketCORS
 		bucket.Methods("DELETE").HandlerFunc(api.DeleteBucketCorsHandler).Queries("cors", "")
+		//PutBucketLogging
+		bucket.Methods("PUT").HandlerFunc(api.PutBucketLoggingHandler).Queries("logging", "")
+		// GetBucketLogging
+		bucket.Methods("GET").HandlerFunc(api.GetBucketLoggingHandler).Queries("logging", "")
 		// PutLifeCycleConfig
 		bucket.Methods("PUT").HandlerFunc(api.PutBucketLifeCycleHandler).Queries("lifecycle", "")
 		// GetLifeCycleConfig

--- a/api/bucket-handlers.go
+++ b/api/bucket-handlers.go
@@ -382,6 +382,86 @@ func (api ObjectAPIHandlers) PutBucketHandler(w http.ResponseWriter, r *http.Req
 	WriteSuccessResponse(w, nil)
 }
 
+func (api ObjectAPIHandlers) PutBucketLoggingHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	bucket := vars["bucket"]
+	var credential common.Credential
+	var err error
+	if credential, err = signature.IsReqAuthenticated(r); err != nil {
+		WriteErrorResponse(w, r, err)
+		return
+	}
+
+	var bl BucketLoggingStatus
+	blBuffer, err := ioutil.ReadAll(io.LimitReader(r.Body, 4096))
+	if err != nil {
+		helper.Logger.Error(r.Context(), "Unable to read bucket logging body", err)
+		WriteErrorResponse(w, r, ErrInvalidBucketLogging)
+		return
+	}
+	err = xml.Unmarshal(blBuffer, &bl)
+	if err != nil {
+		helper.Logger.Error(r.Context(), "Unable to parse bucket logging XML body", err)
+		WriteErrorResponse(w, r, ErrInternalError)
+		return
+	}
+	helper.Logger.Info(r.Context(), "Setting bucket logging:", bl)
+
+	err = api.ObjectAPI.SetBucketLogging(r.Context(), bucket, bl, credential)
+	if err != nil {
+		helper.Logger.Error(r.Context(), "Unable to set bucket logging for bucket", err)
+		WriteErrorResponse(w, r, err)
+		return
+	}
+	// ResponseRecorder
+	w.(*ResponseRecorder).operationName = "PutBucketLogging"
+	WriteSuccessResponse(w, nil)
+}
+
+func (api ObjectAPIHandlers) GetBucketLoggingHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	bucketName := vars["bucket"]
+
+	var credential common.Credential
+	var err error
+	switch signature.GetRequestAuthType(r) {
+	default:
+		// For all unknown auth types return error.
+		WriteErrorResponse(w, r, ErrAccessDenied)
+		return
+	case signature.AuthTypeAnonymous:
+		break
+	case signature.AuthTypePresignedV4, signature.AuthTypeSignedV4,
+		signature.AuthTypePresignedV2, signature.AuthTypeSignedV2:
+		if credential, err = signature.IsReqAuthenticated(r); err != nil {
+			WriteErrorResponse(w, r, err)
+			return
+		}
+	}
+
+	bl, err := api.ObjectAPI.GetBucketLogging(r.Context(), bucketName, credential)
+	if err != nil {
+		helper.Logger.Error(r.Context(), "Failed to get bucket ACL policy for bucket", bucketName,
+			"error")
+		WriteErrorResponse(w, r, err)
+		return
+	}
+
+	blBuffer, err := xmlFormat(bl)
+	if err != nil {
+		helper.Logger.Error(r.Context(), "Failed to marshal bucket logging XML for bucket", bucketName,
+			"error:", err)
+		WriteErrorResponse(w, r, ErrInternalError)
+		return
+	}
+
+	//	setXmlHeader(w)
+	//ResponseRecorder
+	w.(*ResponseRecorder).operationName = "GetBucketLogging"
+	WriteSuccessResponse(w, blBuffer)
+
+}
+
 func (api ObjectAPIHandlers) PutBucketLifeCycleHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	bucket := vars["bucket"]

--- a/api/datatype/bucket-logging.go
+++ b/api/datatype/bucket-logging.go
@@ -1,0 +1,10 @@
+package datatype
+
+type BucketLoggingStatus struct {
+	LoggingEnabled BucketLoggingRule `xml:"LoggingEnabled"`
+}
+
+type BucketLoggingRule struct {
+	TargetBucket string `xml:"TargetBucket"`
+	TargetPrefix string `xml:"TargetPrefix"`
+}

--- a/api/generic-handlers.go
+++ b/api/generic-handlers.go
@@ -286,7 +286,6 @@ func ignoreNotImplementedObjectResources(req *http.Request) bool {
 
 // List of not implemented bucket queries
 var notimplementedBucketResourceNames = map[string]bool{
-	"logging":        true,
 	"notification":   true,
 	"replication":    true,
 	"tagging":        true,

--- a/api/log-replacer.go
+++ b/api/log-replacer.go
@@ -293,7 +293,13 @@ func (r *replacer) getSubstitution(key string) string {
 		return "-"
 
 	case "{bucket_logging}":
-		// TODO: Add bucket logging
+		bl := r.request.Context().Value(RequestContextKey).(RequestContext).BucketInfo
+		//		bl := getRequestContext(r.request).BucketInfo
+		if bl != nil {
+			if bl.BucketLogging.LoggingEnabled.TargetBucket != "" && bl.BucketLogging.LoggingEnabled.TargetPrefix != "" {
+				return strconv.FormatBool(true)
+			}
+		}
 		return strconv.FormatBool(false)
 	case "{cdn_request}":
 		// If you have another judgment method, implement and replace the judgeFunc

--- a/api/object-interface.go
+++ b/api/object-interface.go
@@ -1,17 +1,17 @@
 /*
- * Minio Cloud Storage, (C) 2016 Minio, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+* Minio Cloud Storage, (C) 2016 Minio, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
  */
 
 package api
@@ -34,6 +34,8 @@ type ObjectLayer interface {
 		credential common.Credential) error
 	GetBucketLc(ctx context.Context, bucket string, credential common.Credential) (datatype.Lc, error)
 	DelBucketLc(ctx context.Context, bucket string, credential common.Credential) error
+	SetBucketLogging(ctx context.Context, bucket string, config datatype.BucketLoggingStatus, credential common.Credential) error
+	GetBucketLogging(ctx context.Context, bucket string, credential common.Credential) (datatype.BucketLoggingStatus, error)
 	SetBucketAcl(ctx context.Context, bucket string, policy datatype.AccessControlPolicy, acl datatype.Acl,
 		credential common.Credential) error
 	GetBucketAcl(ctx context.Context, bucket string, credential common.Credential) (datatype.AccessControlPolicyResponse, error)

--- a/error/api-errors.go
+++ b/error/api-errors.go
@@ -144,6 +144,7 @@ const (
 	ErrInvalidAcl
 	ErrUnsupportedAcl
 	ErrNonUTF8Encode
+	ErrInvalidBucketLogging
 	ErrInvalidLc
 	ErrNoSuchBucketLc
 	ErrInvalidStorageClass

--- a/integrate/yig.sql
+++ b/integrate/yig.sql
@@ -26,6 +26,7 @@ CREATE TABLE `buckets` (
   `bucketname` varchar(255) NOT NULL DEFAULT '',
   `acl` JSON DEFAULT NULL,
   `cors` JSON DEFAULT NULL,
+  `logging` JSON NOT NULL DEFAULT '',
   `lc` JSON DEFAULT NULL,
   `uid` varchar(255) DEFAULT NULL,
   `policy` JSON DEFAULT NULL,

--- a/meta/types/bucket.go
+++ b/meta/types/bucket.go
@@ -31,15 +31,16 @@ type Bucket struct {
 	Name string
 	// Date and time when the bucket was created,
 	// should be serialized into format "2006-01-02T15:04:05.000Z"
-	CreateTime time.Time
-	OwnerId    string
-	CORS       datatype.Cors
-	ACL        datatype.Acl
-	LC         datatype.Lc
-	Policy     policy.Policy
-	Versioning string // actually enum: Disabled/Enabled/Suspended
-	Usage      int64
-	UpdateTime time.Time
+	CreateTime    time.Time
+	OwnerId       string
+	CORS          datatype.Cors
+	ACL           datatype.Acl
+	LC            datatype.Lc
+	BucketLogging datatype.BucketLoggingStatus
+	Policy        policy.Policy
+	Versioning    string // actually enum: Disabled/Enabled/Suspended
+	Usage         int64
+	UpdateTime    time.Time
 }
 
 // implements the Serializable interface
@@ -96,6 +97,7 @@ func (b *Bucket) String() (s string) {
 	s += "OwnerId: " + b.OwnerId + "\n"
 	s += "CORS: " + fmt.Sprintf("%+v", b.CORS) + "\n"
 	s += "ACL: " + fmt.Sprintf("%+v", b.ACL) + "\n"
+	s += "BucketLogging: " + fmt.Sprintf("%+v", b.BucketLogging) + "\n"
 	s += "LifeCycle: " + fmt.Sprintf("%+v", b.LC) + "\n"
 	s += "Policy: " + fmt.Sprintf("%+v", b.Policy) + "\n"
 	s += "Version: " + b.Versioning + "\n"
@@ -142,9 +144,10 @@ func (b Bucket) GetUpdateSql() (string, []interface{}) {
 	acl, _ := json.Marshal(b.ACL)
 	cors, _ := json.Marshal(b.CORS)
 	lc, _ := json.Marshal(b.LC)
+	logging, _ := json.Marshal(b.BucketLogging)
 	bucket_policy, _ := json.Marshal(b.Policy)
-	sql := "update buckets set bucketname=?,acl=?,policy=?,cors=?,lc=?,uid=?,versioning=? where bucketname=?"
-	args := []interface{}{b.Name, acl, bucket_policy, cors, lc, b.OwnerId, b.Versioning, b.Name}
+	sql := "update buckets set bucketname=?,acl=?,policy=?,cors=?,logging=?,lc=?,uid=?,versioning=? where bucketname=?"
+	args := []interface{}{b.Name, acl, bucket_policy, cors, logging, lc, b.OwnerId, b.Versioning, b.Name}
 	return sql, args
 }
 
@@ -152,11 +155,11 @@ func (b Bucket) GetCreateSql() (string, []interface{}) {
 	acl, _ := json.Marshal(b.ACL)
 	cors, _ := json.Marshal(b.CORS)
 	lc, _ := json.Marshal(b.LC)
+	logging, _ := json.Marshal(b.BucketLogging)
 	bucket_policy, _ := json.Marshal(b.Policy)
 	createTime := b.CreateTime.Format(TIME_LAYOUT_TIDB)
 
-	sql := "insert into buckets(bucketname,acl,cors,lc,uid,policy,createtime,usages,versioning) " +
-		"values(?,?,?,?,?,?,?,?,?);"
-	args := []interface{}{b.Name, acl, cors, lc, b.OwnerId, bucket_policy, createTime, b.Usage, b.Versioning}
+	sql := "insert into buckets(bucketname,acl,cors,logging,lc,uid,policy,createtime,usages,versioning) " + "values(?,?,?,?,?,?,?,?,?,?);"
+	args := []interface{}{b.Name, acl, cors, logging, lc, b.OwnerId, bucket_policy, createTime, b.Usage, b.Versioning}
 	return sql, args
 }

--- a/test/go/bucketlogging_test.go
+++ b/test/go/bucketlogging_test.go
@@ -1,0 +1,64 @@
+package _go
+import (
+	. "github.com/journeymidnight/yig/test/go/lib"
+	"github.com/journeymidnight/aws-sdk-go/service/s3"
+	"github.com/journeymidnight/aws-sdk-go/aws"
+	"testing"
+)
+
+func Test_BucketLogging_Prepare(t *testing.T) {
+	sc := NewS3()
+	err := sc.MakeBucket(TEST_BUCKET)
+	if err != nil {
+		t.Fatal("MakeBucket err:", err)
+		panic(err)
+	}
+	t.Log("MakeBucket Success.")
+}
+
+func Test_PutBucketLogging(t *testing.T) {
+	sc := NewS3()
+	rules := &s3.LoggingEnabled{
+		TargetBucket: aws.String("testTargetBucket"),
+		TargetPrefix: aws.String("testTargetPrefix"),
+	}
+	err := sc.PutBucketLogging(TEST_BUCKET, rules)
+	if err != nil {
+		t.Fatal("PutBucketLogging err:", err)
+		panic(err)
+	}
+	t.Log("PutBucketLogging Success.")
+}
+
+func Test_GetBucketLogging(t *testing.T) {
+	sc := NewS3()
+	out,err := sc.GetBucketLogging(TEST_BUCKET)
+	if err != nil {
+		t.Fatal("GetBucketLogging err:", err)
+		panic(err)
+	}
+	t.Log("GetBucketAcl Success! out:", out)
+}
+
+func Test_DeleteBucketLogging(t *testing.T) {
+	sc := NewS3()
+	rules := &s3.LoggingEnabled{
+		TargetBucket: aws.String(""),
+		TargetPrefix: aws.String(""),
+	}
+	err := sc.PutBucketLogging(TEST_BUCKET, rules)
+	if err != nil {
+		t.Fatal("DeleteBucketLogging err:", err)
+		panic(err)
+	}
+	t.Log("DeleteBucketLogging Success.")
+}
+func Test_BucketLogging_End(t *testing.T) {
+	sc := NewS3()
+	err := sc.DeleteBucket(TEST_BUCKET)
+	if err != nil {
+		t.Fatal("DeleteBucket err:", err)
+		panic(err)
+	}
+
+}

--- a/test/go/lib/bucketlogging.go
+++ b/test/go/lib/bucketlogging.go
@@ -1,0 +1,29 @@
+package lib
+
+import (
+	"github.com/journeymidnight/aws-sdk-go/aws"
+	"github.com/journeymidnight/aws-sdk-go/service/s3"
+)
+
+func (s3client *S3Client) PutBucketLogging(bucketName string, rules *s3.LoggingEnabled) (err error) {
+	params := &s3.PutBucketLoggingInput{
+		Bucket: aws.String(bucketName),
+		BucketLoggingStatus: &s3.BucketLoggingStatus{LoggingEnabled: rules},
+
+	}
+	if _, err = s3client.Client.PutBucketLogging(params); err != nil {
+		return err
+	}
+	return
+}
+
+func (s3client *S3Client) GetBucketLogging(bucketName string) (rules *s3.GetBucketLoggingOutput,err error) {
+	params := &s3.GetBucketLoggingInput{
+		Bucket: aws.String(bucketName),
+	}
+	rules, err = s3client.Client.GetBucketLogging(params)
+	if  err != nil {
+		return nil,err
+	}
+	return rules,nil
+}


### PR DESCRIPTION
Backport feature bucketlogging from journeymidnight.
Merged commits on journeymidnight/yig as follows. And compared with journeymidnight/yig/master branch manually.

commit e006b9d2e4dc762f33ac3b0f1592d0d18d81513c
Author: imegao <44913208+imegao@users.noreply.github.com>
Date:   Tue Mar 3 04:17:47 2020 +0800

    add bucket logging (#249)

    * add bucket logging function

    * Correct some naming errors

    * Remove not implemented

    * add log-replacer

    * change database sql

    * update yig sql file

    * fix sql file bug

    * add bucket logging test sample

    * add bucket logging lib

    * import aws package

    * fix bucketlogging test bugs

    * test question about CI can not pass

    * test the question about CI can not pass

    * add test end

    * change bl to logging

    * del redundant and add check bucket owner

    * change to compare logic to API layer

    * delete meta layer credential

Test case
1.test/go/bucketlogging-test.go
2. s3tests as follow
    PASS casesPASS cases

  S3TEST_CONF=aws-s3.conf ./virtualenv/bin/nosetests s3tests_boto3.functional.test_s3:test_logging_toggle
Signed-off-by: Shenghai <18366182863@163.com>