### PR TITLE
Yig: add cors and lifcycle rules limit

### DIFF
--- a/api/datatype/cors.go
+++ b/api/datatype/cors.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	MAX_CORS_SIZE = 64 << 10 // 64 KB
+	MAX_CORS_SIZE  = 64 << 10 // 64 KB
+	MAX_CORS_RULES = 100
 )
 
 type CorsRule struct {
@@ -113,8 +114,9 @@ func CorsFromXml(ctx context.Context, corsBuffer []byte) (cors Cors, err error) 
 		helper.ErrorIf(err, "Unable to unmarshal CORS XML")
 		return cors, ErrInvalidCorsDocument
 	}
-	if len(cors.CorsRules) == 0 {
-		return cors, ErrInvalidCorsDocument
+	if len(cors.CorsRules) == 0 || len(cors.CorsRules) > MAX_CORS_RULES {
+		helper.ErrorIf(nil, "Number of rules is invalid, rules =  ", len(cors.CorsRules))
+		return cors, ErrInvalidNumberOfRules
 	}
 	for _, rule := range cors.CorsRules {
 		if len(rule.AllowedMethods) == 0 || len(rule.AllowedOrigins) == 0 {

--- a/api/datatype/lifecycle.go
+++ b/api/datatype/lifecycle.go
@@ -1,9 +1,15 @@
 package datatype
 
 import (
+	"context"
 	"encoding/xml"
-	//	. "github.com/journeymidnight/yig/error"
-	//	"github.com/journeymidnight/yig/helper"
+
+	. "github.com/journeymidnight/yig/error"
+	"github.com/journeymidnight/yig/helper"
+)
+
+const (
+	MAX_LIFCYCLE_RULES = 1000
 )
 
 type LcRule struct {
@@ -16,4 +22,18 @@ type LcRule struct {
 type Lc struct {
 	XMLName xml.Name `xml:"LifecycleConfiguration"`
 	Rule    []LcRule `xml:"Rule"`
+}
+
+func LifcycleFromXml(ctx context.Context, lifcycleBuffer []byte) (lc Lc, err error) {
+	helper.Logger.Info(ctx, "Incoming Lifcycle XML:", string(lifcycleBuffer))
+	err = xml.Unmarshal(lifcycleBuffer, &lc)
+	if err != nil {
+		helper.ErrorIf(err, "Unable to unmarshal Lifcycle XML")
+		return lc, ErrInvalidLifcycleDocument
+	}
+	if len(lc.Rule) == 0 || len(lc.Rule) > MAX_LIFCYCLE_RULES {
+		helper.ErrorIf(nil, "Number of rules is invalid, rules = ", len(lc.Rule))
+		return lc, ErrInvalidNumberOfRules
+	}
+	return lc, nil
 }

--- a/error/api-errors.go
+++ b/error/api-errors.go
@@ -169,6 +169,8 @@ const (
 	ErrIndexDocumentNotAllowed
 	ErrInvalidIndexDocumentSuffix
 	ErrInvalidErrorDocumentKey
+	ErrInvalidLifcycleDocument
+	ErrInvalidNumberOfRules
 )
 
 // error code to APIError structure, these fields carry respective
@@ -768,6 +770,16 @@ var ErrorCodeResponse = map[ApiErrorCode]ApiErrorStruct{
 	ErrInvalidErrorDocumentKey: {
 		AwsErrorCode:   "InvalidErrorDocumentKey",
 		Description:    "The key is required when ErrorDocument is specified.",
+		HttpStatusCode: http.StatusBadRequest,
+	},
+	ErrInvalidLifcycleDocument: {
+		AwsErrorCode:   "InvalidLifecycleDocument",
+		Description:    "The LC XML you provided is invalid",
+		HttpStatusCode: http.StatusBadRequest,
+	},
+	ErrInvalidNumberOfRules: {
+		AwsErrorCode:   "InvalidNumberOfRules",
+		Description:    "The number of rules you provided exceeds is invalid",
 		HttpStatusCode: http.StatusBadRequest,
 	},
 }


### PR DESCRIPTION
Add  lc and cors rule entry  limit(max lc rules = 1000;   max cors rules =100). Lc rule size is specified by content-length
Signed-off-by: Shenghai <18366182863@163.com>